### PR TITLE
Fix telegram not sending message

### DIFF
--- a/kibitzr/notifier/telegram.py
+++ b/kibitzr/notifier/telegram.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 import logging
+import asyncio
 
 from ..conf import settings
 
@@ -47,6 +48,7 @@ class TelegramBot:
             message,
             parse_mode='Markdown',
         )
+        asyncio.run(message)
         return message
 
     __call__ = post


### PR DESCRIPTION
Bot.send_message() is an async function. Calling send_message directly will just return a coroutine object instead of execute the function. I was getting 
"/kibitzr/kibitzr/notifier/telegram.py:43: RuntimeWarning: coroutine 'Bot.send_message' was never awaited
  self.send_message(m)"
warning, which indicates the coroutine object/function is not given an opportunity to run. So the message was never send out.